### PR TITLE
[#153] feat : 아이템 scrap 로직 추가

### DIFF
--- a/src/main/java/com/sluv/server/domain/closet/controller/ClosetController.java
+++ b/src/main/java/com/sluv/server/domain/closet/controller/ClosetController.java
@@ -55,4 +55,20 @@ public class ClosetController {
                 new SuccessResponse()
         );
     }
+    @Operation(
+            summary = "*옷장에 아이템 스크랩(저장하기)",
+            description = """ 
+                    사용자 옷장에 아이템을 스크랩(저장하기)
+                    User Id Token 필요 -> 해당 옷장의 소유자인지 확인
+                    ** 일단 1개의 아이템은 유저당 1개의 옷장에만 저장 가능**
+                    A유저가 가지고 있는 1번 2번 옷장에 저장 불가. 1번 혹은 2번에만 저장 가능.
+                    """
+    )
+    @PostMapping("/{itemId}/scrap/{closetId}")
+    public ResponseEntity<SuccessResponse> postItemScrapToCloset(@AuthenticationPrincipal User user, @PathVariable("itemId") Long itemId, @PathVariable("closetId") Long closetId){
+        closetService.postItemScrapToCloset(user, itemId, closetId);
+        return ResponseEntity.ok().body(
+                new SuccessResponse()
+        );
+    }
 }

--- a/src/main/java/com/sluv/server/domain/closet/service/ClosetService.java
+++ b/src/main/java/com/sluv/server/domain/closet/service/ClosetService.java
@@ -6,6 +6,10 @@ import com.sluv.server.domain.closet.enums.ClosetStatus;
 import com.sluv.server.domain.closet.exception.BasicClosetDeleteException;
 import com.sluv.server.domain.closet.exception.ClosetNotFoundException;
 import com.sluv.server.domain.closet.repository.ClosetRepository;
+import com.sluv.server.domain.item.entity.Item;
+import com.sluv.server.domain.item.entity.ItemScrap;
+import com.sluv.server.domain.item.exception.ItemNotFoundException;
+import com.sluv.server.domain.item.repository.ItemRepository;
 import com.sluv.server.domain.item.repository.ItemScrapRepository;
 import com.sluv.server.domain.user.entity.User;
 import com.sluv.server.domain.user.exception.UserNotMatchedException;
@@ -20,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClosetService {
     private final ClosetRepository closetRepository;
     private final ItemScrapRepository itemScrapRepository;
+    private final ItemRepository itemRepository;
 
     public void postBasicCloset(User user){
 
@@ -85,5 +90,26 @@ public class ClosetService {
 
         log.info("Delete Closet Id: {}", closet.getId());
         closetRepository.deleteById(closet.getId());
+    }
+
+    @Transactional
+    public void postItemScrapToCloset(User user, Long itemId, Long closetId) {
+        Item item = itemRepository.findById(itemId).orElseThrow(ItemNotFoundException::new);
+        Closet closet = closetRepository.findById(closetId).orElseThrow(ClosetNotFoundException::new);
+
+        if(!closet.getUser().getId().equals(user.getId())){
+            log.info( "User did Not Matched. User Id: {}, Closet Owner Id : {}",user.getId(), closet.getUser().getId());
+            throw new UserNotMatchedException();
+        }
+
+        log.info("Save ItemScrap with item Id: {}, Closet Id {}", item.getId(), closet.getId());
+        ItemScrap saveItemScrap = itemScrapRepository.save(
+                ItemScrap.builder()
+                        .item(item)
+                        .closet(closet)
+                        .build()
+        );
+        log.info("Save Success with ItemScrap Id: {}", saveItemScrap.getId());
+
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/#153-POST-app-closet-itemId-scrap-closetId -> develop

### 변경 사항
- 특정 Closet에 Item을 스크랩하는 기능 추가
- 한개의 아이템은 특정 유저의 1개의 옷장에만 저장될 수 있다. (특정 유저의 여러 옷장에 한개의 아이템을 여러번 저장할 수 없다)

### 테스트 결과
X
