### PR TITLE
Feature/#177 get app search item count

### DIFF
--- a/src/main/java/com/sluv/server/domain/item/repository/impl/ItemRepositoryCustom.java
+++ b/src/main/java/com/sluv/server/domain/item/repository/impl/ItemRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.sluv.server.domain.item.repository.impl;
 
 import com.sluv.server.domain.closet.entity.Closet;
 import com.sluv.server.domain.item.entity.Item;
+import com.sluv.server.domain.search.dto.SearchFilterReqDto;
 import com.sluv.server.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,4 +26,6 @@ public interface ItemRepositoryCustom {
     Page<Item> getSearchItem(List<Long> itemIdList, Pageable pageable);
 
     Page<Item> getRecommendItemPage(Pageable pageable);
+
+    Long getSearchItemCount(List<Long> itemIdList, SearchFilterReqDto dto);
 }

--- a/src/main/java/com/sluv/server/domain/search/controller/SearchController.java
+++ b/src/main/java/com/sluv/server/domain/search/controller/SearchController.java
@@ -2,6 +2,8 @@ package com.sluv.server.domain.search.controller;
 
 import com.sluv.server.domain.item.dto.ItemSimpleResDto;
 import com.sluv.server.domain.question.dto.QuestionSimpleResDto;
+import com.sluv.server.domain.search.dto.SearchFilterReqDto;
+import com.sluv.server.domain.search.dto.SearchItemCountResDto;
 import com.sluv.server.domain.search.dto.SearchTotalResDto;
 import com.sluv.server.domain.search.service.SearchService;
 import com.sluv.server.domain.user.dto.UserSearchInfoDto;
@@ -13,10 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/app/search")
@@ -94,6 +93,21 @@ public class SearchController {
         return ResponseEntity.ok().body(
                 SuccessDataResponse.<SearchTotalResDto>builder()
                         .result(searchService.getSearchTotal(user, keyword))
+                        .build()
+        );
+    }
+
+    @Operation(
+            summary = "필터링 조건에 따른 아이템 개수 조회",
+            description = """
+                    필터링 조건에 맞는 아이템 개수를 조회하는 기능
+                    """
+    )
+    @GetMapping("/item/count")
+    public ResponseEntity<SuccessDataResponse<SearchItemCountResDto>> searchItemCount(@RequestParam("keyword") String keyword, SearchFilterReqDto dto){
+        return ResponseEntity.ok().body(
+                SuccessDataResponse.<SearchItemCountResDto>builder()
+                        .result(searchService.getSearchItemCount(keyword, dto))
                         .build()
         );
     }

--- a/src/main/java/com/sluv/server/domain/search/dto/SearchFilterReqDto.java
+++ b/src/main/java/com/sluv/server/domain/search/dto/SearchFilterReqDto.java
@@ -1,0 +1,13 @@
+package com.sluv.server.domain.search.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class SearchFilterReqDto {
+    private Long categoryId;
+    private Long minPrice;
+    private Long maxPrice;
+    private String color;
+}

--- a/src/main/java/com/sluv/server/domain/search/dto/SearchItemCountResDto.java
+++ b/src/main/java/com/sluv/server/domain/search/dto/SearchItemCountResDto.java
@@ -1,0 +1,14 @@
+package com.sluv.server.domain.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SearchItemCountResDto {
+    private Long itemCount;
+}

--- a/src/main/java/com/sluv/server/domain/search/service/SearchService.java
+++ b/src/main/java/com/sluv/server/domain/search/service/SearchService.java
@@ -15,6 +15,8 @@ import com.sluv.server.domain.question.repository.QuestionImgRepository;
 import com.sluv.server.domain.question.repository.QuestionItemRepository;
 import com.sluv.server.domain.question.repository.QuestionRecommendCategoryRepository;
 import com.sluv.server.domain.question.repository.QuestionRepository;
+import com.sluv.server.domain.search.dto.SearchFilterReqDto;
+import com.sluv.server.domain.search.dto.SearchItemCountResDto;
 import com.sluv.server.domain.search.dto.SearchTotalResDto;
 import com.sluv.server.domain.search.utils.ElasticSearchConnectUtil;
 import com.sluv.server.domain.user.dto.UserSearchInfoDto;
@@ -287,6 +289,18 @@ public class SearchService {
                 .itemList(searchItem)
                 .questionList(searchQuestion)
                 .userList(searchUser)
+                .build();
+    }
+
+    public SearchItemCountResDto getSearchItemCount(String keyword, SearchFilterReqDto dto) {
+        // ElasticSearch API Path
+        String itemPath = "/search/searchItem";
+
+        // ElasticSearch 에서 Keyword에 해당하는 Item의 Id 조회
+        List<Long> itemIdList = elasticSearchConnectUtil.connectElasticSearch(keyword, itemPath);
+
+        return SearchItemCountResDto.builder()
+                .itemCount(itemRepository.getSearchItemCount(itemIdList, dto))
                 .build();
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/#177-GEt-app-search-item-count -> develop

### 변경 사항
- 아이템 검색 시 Filtering 추가 시 검색될 아이템 총 개수 구하는 기능 추가

### 테스트 결과
- ElasticSearch 서버 주소가 없으므로 테스트 연기
