### PR TITLE
S2D-83 refactor : Item 상세조회 API 분리

### DIFF
--- a/src/main/java/com/sluv/server/domain/closet/repository/impl/ClosetRepositoryCustom.java
+++ b/src/main/java/com/sluv/server/domain/closet/repository/impl/ClosetRepositoryCustom.java
@@ -2,14 +2,13 @@ package com.sluv.server.domain.closet.repository.impl;
 
 import com.sluv.server.domain.closet.dto.ClosetResDto;
 import com.sluv.server.domain.closet.entity.Closet;
-import com.sluv.server.domain.item.entity.Item;
 import com.sluv.server.domain.user.entity.User;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ClosetRepositoryCustom {
-    List<Closet> getRecentAddCloset(Item item);
+    List<Closet> getRecentAddCloset(Long itemId);
 
     Page<Closet> getUserAllCloset(Long userId, Pageable pageable);
 

--- a/src/main/java/com/sluv/server/domain/closet/repository/impl/ClosetRepositoryImpl.java
+++ b/src/main/java/com/sluv/server/domain/closet/repository/impl/ClosetRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sluv.server.domain.closet.dto.ClosetResDto;
 import com.sluv.server.domain.closet.entity.Closet;
 import com.sluv.server.domain.closet.enums.ClosetStatus;
-import com.sluv.server.domain.item.entity.Item;
 import com.sluv.server.domain.user.entity.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +21,12 @@ public class ClosetRepositoryImpl implements ClosetRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Closet> getRecentAddCloset(Item item) {
+    public List<Closet> getRecentAddCloset(Long itemId) {
         // 상위 20개 추출
         return jpaQueryFactory.select(closet)
                 .from(itemScrap)
                 .leftJoin(itemScrap.closet, closet)
-                .where(itemScrap.item.eq(item))
+                .where(itemScrap.item.id.eq(itemId))
                 .limit(20)
                 .orderBy(itemScrap.createdAt.desc())
                 .fetch();

--- a/src/main/java/com/sluv/server/domain/item/controller/ItemController.java
+++ b/src/main/java/com/sluv/server/domain/item/controller/ItemController.java
@@ -36,9 +36,7 @@ public class ItemController {
     private final ItemService itemService;
 
     /**
-     * 같은 셀럽 아이템 리스트 -> 10개 같은 브랜드 아이템 리스트 -> 10개 다른 스러버들이 함께 보관한 아이템 리스트 -> 10개 1. 같은 셀럽의 아이템 -> 셀럽을 기준으로 최신 아이템 검색 2.
-     * 같은 브랜드의 아이템 -> 브랜드를 기준으로 최신 아이템 검색 3. 함께 스크랩한 아이템 -> a. 해당 아이템을 저장한 Closet을 최신순으로 20개 추출 b. 20개의 Closet의 모든 Item을
-     * 최신순으로 정렬 c. 정렬된 것중 상위 10개 추출.
+     * 아이템 상세조회
      */
     @Operation(summary = "*특정 아이템 게시글 상세조회", description = "User 토큰 필요")
     @GetMapping("/{itemId}")
@@ -48,6 +46,52 @@ public class ItemController {
         return ResponseEntity.ok().body(
                 SuccessDataResponse.<ItemDetailResDto>builder()
                         .result(itemService.getItemDetail(user, itemId))
+                        .build()
+        );
+    }
+
+    /**
+     * 같은 셀럽 아이템 리스트 -> 10개 같은 브랜드 아이템 리스트 -> 10개
+     */
+    @Operation(summary = "*같은 셀럽 아이템 리스트 조회", description = "User 토큰 필요")
+    @GetMapping("/sameCelebItem")
+    public ResponseEntity<SuccessDataResponse<List<ItemSimpleResDto>>> getSameCelebItem(
+            @AuthenticationPrincipal User user, @RequestParam("itemId") Long itemId) {
+
+        return ResponseEntity.ok().body(
+                SuccessDataResponse.<List<ItemSimpleResDto>>builder()
+                        .result(itemService.getSameCelebItems(user, itemId))
+                        .build()
+        );
+    }
+
+    /**
+     * 같은 브랜드의 아이템 -> 브랜드를 기준으로 최신 아이템 검색 -> 10개
+     */
+    @Operation(summary = "*같은 브랜드의 아이템 리스트 조회", description = "User 토큰 필요")
+    @GetMapping("/sameBrandItem")
+    public ResponseEntity<SuccessDataResponse<List<ItemSimpleResDto>>> getSameBrandItem(
+            @AuthenticationPrincipal User user, @RequestParam("itemId") Long itemId) {
+
+        return ResponseEntity.ok().body(
+                SuccessDataResponse.<List<ItemSimpleResDto>>builder()
+                        .result(itemService.getSameBrandItem(user, itemId))
+                        .build()
+        );
+    }
+
+    /**
+     * 함께 스크랩한 아이템 -> 10개
+     */
+    @Operation(summary = "*함께 스크랩한 아이템 리스트 조회", description = "User 토큰 필요")
+    @GetMapping("/togetherScrap")
+    public ResponseEntity<SuccessDataResponse<List<ItemSimpleResDto>>> getTogetherScrapItem(
+            @AuthenticationPrincipal User user,
+            @RequestParam("itemId") Long itemId) {
+
+        return ResponseEntity.ok().body(
+                SuccessDataResponse.<List<ItemSimpleResDto>>builder()
+                        .result(itemService.getTogetherScrapItem(user, itemId))
                         .build()
         );
     }

--- a/src/main/java/com/sluv/server/domain/item/dto/ItemDetailResDto.java
+++ b/src/main/java/com/sluv/server/domain/item/dto/ItemDetailResDto.java
@@ -66,15 +66,6 @@ public class ItemDetailResDto {
     @Schema(description = "추가정보를 발견한 출처")
     private String infoSource;
 
-    @Schema(description = "같은 셀럽 아이템 리스트")
-    private List<ItemSimpleResDto> sameCelebItemList;
-
-    @Schema(description = "같은 브랜드 아이템 리스트")
-    private List<ItemSimpleResDto> sameBrandItemList;
-
-    @Schema(description = "다른 스러버들이 함께 보관한 아이템 리스트")
-    private List<ItemSimpleResDto> otherSluverItemList;
-
     @Schema(description = "색")
     private String color;
 
@@ -89,10 +80,7 @@ public class ItemDetailResDto {
                                       Integer likeNum, Boolean likeStatus, Integer scrapNum, Boolean scrapStatus,
                                       Long viewNum, UserInfoDto writerInfo, Boolean followStatus, Boolean hasMine,
                                       List<ItemImgResDto> imgList, List<ItemLinkResDto> linkList,
-                                      List<HashtagResponseDto> hashtagList,
-                                      List<ItemSimpleResDto> sameCelebItemList,
-                                      List<ItemSimpleResDto> sameBrandItemList,
-                                      List<ItemSimpleResDto> otherSluverItemList
+                                      List<HashtagResponseDto> hashtagList
     ) {
 
         return ItemDetailResDto.builder()
@@ -116,9 +104,6 @@ public class ItemDetailResDto {
                 .additionalInfo(item.getAdditionalInfo())
                 .hashTagList(hashtagList)
                 .infoSource(item.getInfoSource())
-                .sameCelebItemList(sameCelebItemList)
-                .sameBrandItemList(sameBrandItemList)
-                .otherSluverItemList(otherSluverItemList)
                 .followStatus(followStatus)
                 .hasMine(hasMine)
                 .color(item.getColor())

--- a/src/main/java/com/sluv/server/domain/item/repository/impl/ItemRepositoryCustom.java
+++ b/src/main/java/com/sluv/server/domain/item/repository/impl/ItemRepositoryCustom.java
@@ -13,9 +13,9 @@ import org.springframework.data.domain.Pageable;
 public interface ItemRepositoryCustom {
     List<String> findTopPlace();
 
-    List<Item> findSameCelebItem(Item item, boolean celebJudge);
+    List<Item> findSameCelebItem(Long itemId, Long celebId, boolean celebJudge);
 
-    List<Item> findSameBrandItem(Item item, boolean brandJudge);
+    List<Item> findSameBrandItem(Long itemId, Long brandId, boolean brandJudge);
 
     Page<Item> getRecentItem(User user, Pageable pageable);
 
@@ -23,7 +23,7 @@ public interface ItemRepositoryCustom {
 
     Page<ItemSimpleResDto> getClosetItems(Closet closet, Pageable pageable);
 
-    List<Item> getSameClosetItems(Item item, List<Closet> closetList);
+    List<Item> getSameClosetItems(Long itemId, List<Closet> closetList);
 
     Page<Item> getSearchItem(List<Long> itemIdList, SearchFilterReqDto dto, Pageable pageable);
 
@@ -68,4 +68,6 @@ public interface ItemRepositoryCustom {
     List<ItemSimpleResDto> getItemSimpleResDto(User user, List<Item> items);
 
     Page<Item> getUserAllRecentItem(User user, Pageable pageable);
+
+    Item getItemByIdWithCelebAndBrand(Long itemId);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/S2D-83 -> develop

### 변경 사항
Item 상세조회 API를 다음 4개의 API로 분리
- Item 상세조회 API
- 같은 Celeb Item 리스트 조회 API
- 같은 Brand Item 리스트 조회 API
- 같은 Closet에 저장된 Item 리스트 조회 API

### 테스트 결과
X
