### PR TITLE
Feature/clean post

### DIFF
--- a/sluv-admin/src/main/java/com/sluv/admin/celeb/dto/CelebSelfPostRequest.java
+++ b/sluv-admin/src/main/java/com/sluv/admin/celeb/dto/CelebSelfPostRequest.java
@@ -3,7 +3,7 @@ package com.sluv.admin.celeb.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 
 @Getter
 @ToString

--- a/sluv-admin/src/main/java/com/sluv/admin/celeb/dto/NewCelebSelfPostRequest.java
+++ b/sluv-admin/src/main/java/com/sluv/admin/celeb/dto/NewCelebSelfPostRequest.java
@@ -2,7 +2,7 @@ package com.sluv.admin.celeb.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 
 @Getter
 @NoArgsConstructor

--- a/sluv-admin/src/main/java/com/sluv/admin/item/controller/ItemDashBoardController.java
+++ b/sluv-admin/src/main/java/com/sluv/admin/item/controller/ItemDashBoardController.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/sluv-admin/src/main/java/com/sluv/admin/router/brand/BrandRouter.java
+++ b/sluv-admin/src/main/java/com/sluv/admin/router/brand/BrandRouter.java
@@ -3,7 +3,7 @@ package com.sluv.admin.router.brand;
 import com.sluv.admin.brand.dto.BrandPageResponse;
 import com.sluv.admin.brand.service.BrandService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/sluv-admin/src/main/java/com/sluv/admin/router/celeb/CelebRouter.java
+++ b/sluv-admin/src/main/java/com/sluv/admin/router/celeb/CelebRouter.java
@@ -5,7 +5,7 @@ import com.sluv.admin.celeb.dto.CelebPageResponse;
 import com.sluv.admin.celeb.service.CelebCategoryService;
 import com.sluv.admin.celeb.service.CelebService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/sluv-api/src/main/java/com/sluv/api/auth/controller/AuthController.java
+++ b/sluv-api/src/main/java/com/sluv/api/auth/controller/AuthController.java
@@ -17,7 +17,7 @@ import com.sluv.infra.counter.visit.VisitCounter;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/sluv-api/src/main/java/com/sluv/api/auth/dto/request/AuthRequest.java
+++ b/sluv-api/src/main/java/com/sluv/api/auth/dto/request/AuthRequest.java
@@ -3,7 +3,7 @@ package com.sluv.api.auth.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 
 @Getter
 @NoArgsConstructor

--- a/sluv-api/src/main/java/com/sluv/api/closet/controller/ClosetController.java
+++ b/sluv-api/src/main/java/com/sluv/api/closet/controller/ClosetController.java
@@ -10,7 +10,7 @@ import com.sluv.common.annotation.CurrentUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/sluv-api/src/main/java/com/sluv/api/moderation/service/QuestionModerationService.java
+++ b/sluv-api/src/main/java/com/sluv/api/moderation/service/QuestionModerationService.java
@@ -1,0 +1,24 @@
+package com.sluv.api.moderation.service;
+
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import com.sluv.domain.featureflag.service.FeatureFlagDomainService;
+import com.sluv.domain.moderation.service.ModerationJobDomainService;
+import com.sluv.domain.question.entity.Question;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionModerationService {
+
+    private final FeatureFlagDomainService featureFlagDomainService;
+    private final ModerationJobDomainService moderationJobDomainService;
+
+    public void createQuestionJobIfEnabled(Question question) {
+        if (!featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_JOB_CREATION)) {
+            return;
+        }
+
+        moderationJobDomainService.createQuestionJobIfAbsent(question.getId(), question.getUser().getId());
+    }
+}

--- a/sluv-api/src/main/java/com/sluv/api/moderation/service/QuestionModerationStatusService.java
+++ b/sluv-api/src/main/java/com/sluv/api/moderation/service/QuestionModerationStatusService.java
@@ -1,0 +1,30 @@
+package com.sluv.api.moderation.service;
+
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import com.sluv.domain.featureflag.service.FeatureFlagDomainService;
+import com.sluv.domain.question.enums.QuestionStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionModerationStatusService {
+
+    private final FeatureFlagDomainService featureFlagDomainService;
+
+    public QuestionStatus getInitialQuestionStatus() {
+        if (featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_QUESTION_CREATE_PENDING)) {
+            return QuestionStatus.PENDING;
+        }
+
+        return QuestionStatus.ACTIVE;
+    }
+
+    public QuestionStatus getUpdateQuestionStatus() {
+        if (featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_QUESTION_UPDATE_PENDING)) {
+            return QuestionStatus.PENDING;
+        }
+
+        return QuestionStatus.ACTIVE;
+    }
+}

--- a/sluv-api/src/main/java/com/sluv/api/question/controller/QuestionController.java
+++ b/sluv-api/src/main/java/com/sluv/api/question/controller/QuestionController.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/sluv-api/src/main/java/com/sluv/api/question/service/QuestionService.java
+++ b/sluv-api/src/main/java/com/sluv/api/question/service/QuestionService.java
@@ -1,6 +1,7 @@
 package com.sluv.api.question.service;
 
 import com.sluv.api.celeb.dto.response.CelebChipResponse;
+import com.sluv.api.moderation.service.QuestionModerationService;
 import com.sluv.api.question.dto.*;
 import com.sluv.api.question.helper.QuestionImageManager;
 import com.sluv.api.question.helper.QuestionItemManager;
@@ -43,6 +44,7 @@ public class QuestionService {
     private final QuestionImageManager questionImageManager;
     private final QuestionItemManager questionItemManager;
     private final QuestionVoteService questionVoteService;
+    private final QuestionModerationService questionModerationService;
 
 
     @Transactional
@@ -78,6 +80,8 @@ public class QuestionService {
         // 4. QuestionItem 저장
         questionItemManager.saveItems(dto.getItemList(), newQuestionFind);
 
+        questionModerationService.createQuestionJobIfEnabled(newQuestionFind);
+
         return QuestionPostResDto.of(newQuestionFind.getId());
 
     }
@@ -106,6 +110,8 @@ public class QuestionService {
         // 4. QuestionItem 저장
         questionItemManager.saveItems(dto.getItemList(), newQuestionBuy);
 
+        questionModerationService.createQuestionJobIfEnabled(newQuestionBuy);
+
         return QuestionPostResDto.of(newQuestionBuy.getId());
     }
 
@@ -133,6 +139,8 @@ public class QuestionService {
 
         // 4. QuestionItem 저장
         questionItemManager.saveItems(dto.getItemList(), newQuestionHowabout);
+
+        questionModerationService.createQuestionJobIfEnabled(newQuestionHowabout);
 
         return QuestionPostResDto.of(newQuestionHowabout.getId());
     }
@@ -173,6 +181,8 @@ public class QuestionService {
 
         // 5. QuestionItem 저장
         questionItemManager.saveItems(dto.getItemList(), newQuestionRecommend);
+
+        questionModerationService.createQuestionJobIfEnabled(newQuestionRecommend);
 
         return QuestionPostResDto.of(newQuestionRecommend.getId());
     }

--- a/sluv-api/src/main/java/com/sluv/api/question/service/QuestionService.java
+++ b/sluv-api/src/main/java/com/sluv/api/question/service/QuestionService.java
@@ -2,6 +2,7 @@ package com.sluv.api.question.service;
 
 import com.sluv.api.celeb.dto.response.CelebChipResponse;
 import com.sluv.api.moderation.service.QuestionModerationService;
+import com.sluv.api.moderation.service.QuestionModerationStatusService;
 import com.sluv.api.question.dto.*;
 import com.sluv.api.question.helper.QuestionImageManager;
 import com.sluv.api.question.helper.QuestionItemManager;
@@ -45,6 +46,7 @@ public class QuestionService {
     private final QuestionItemManager questionItemManager;
     private final QuestionVoteService questionVoteService;
     private final QuestionModerationService questionModerationService;
+    private final QuestionModerationStatusService questionModerationStatusService;
 
 
     @Transactional
@@ -68,8 +70,9 @@ public class QuestionService {
             newCeleb = newCelebDomainService.findByNewCelebIdOrNull(dto.getNewCelebId());
         }
 
+        QuestionStatus questionStatus = getQuestionStatus(dto.getId());
         QuestionFind questionFind = QuestionFind.toEntity(user, dto.getId(), dto.getTitle(), dto.getContent(), celeb,
-                newCeleb);
+                newCeleb, questionStatus);
 
         // 2. QuestionFind 저장
         QuestionFind newQuestionFind = (QuestionFind) questionDomainService.saveQuestion(questionFind);
@@ -99,7 +102,9 @@ public class QuestionService {
                 user.getId(), dto.getId() == null ? null : dto.getId(), dto.getTitle());
 
         // 1. 생성 or 수정
-        QuestionBuy questionBuy = QuestionBuy.toEntity(user, dto.getId(), dto.getTitle(), dto.getVoteEndTime());
+        QuestionStatus questionStatus = getQuestionStatus(dto.getId());
+        QuestionBuy questionBuy = QuestionBuy.toEntity(user, dto.getId(), dto.getTitle(), dto.getVoteEndTime(),
+                questionStatus);
 
         // 2. QuestionBuy 저장
         QuestionBuy newQuestionBuy = (QuestionBuy) questionDomainService.saveQuestion(questionBuy);
@@ -128,8 +133,9 @@ public class QuestionService {
                 user.getId(), dto.getId() == null ? null : dto.getId(), dto.getTitle());
 
         // 1. 생성 or 수정
+        QuestionStatus questionStatus = getQuestionStatus(dto.getId());
         QuestionHowabout questionHowabout = QuestionHowabout.toEntity(user, dto.getId(), dto.getTitle(),
-                dto.getContent());
+                dto.getContent(), questionStatus);
 
         // 2. QuestionHotabout 저장
         QuestionHowabout newQuestionHowabout = (QuestionHowabout) questionDomainService.saveQuestion(questionHowabout);
@@ -158,8 +164,9 @@ public class QuestionService {
         log.info("추천해줘 게시글 등록 or 수정 - 사용자 : {}, 질문 게시글 : {}, 질문 게시글 제목 : {}",
                 user.getId(), dto.getId() == null ? null : dto.getId(), dto.getTitle());
         // 1. 생성 or 수정
+        QuestionStatus questionStatus = getQuestionStatus(dto.getId());
         QuestionRecommend questionRecommend = QuestionRecommend.toEntity(user, dto.getId(), dto.getTitle(),
-                dto.getContent());
+                dto.getContent(), questionStatus);
 
         // 2. QuestionRecommend 저장
         QuestionRecommend newQuestionRecommend = (QuestionRecommend) questionDomainService.saveQuestion(
@@ -238,6 +245,14 @@ public class QuestionService {
         }
 
         return closetDomainService.findAllByUserId(user.getId());
+    }
+
+    private QuestionStatus getQuestionStatus(Long questionId) {
+        if (questionId == null) {
+            return questionModerationStatusService.getInitialQuestionStatus();
+        }
+
+        return questionModerationStatusService.getUpdateQuestionStatus();
     }
 
     private Function<Integer, QuestionVoteDataDto> getVoteDataResolver(Long questionId, String questionType) {

--- a/sluv-api/src/main/java/com/sluv/api/search/controller/SearchController.java
+++ b/sluv-api/src/main/java/com/sluv/api/search/controller/SearchController.java
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/sluv-api/src/test/java/com/sluv/api/domain/moderation/service/QuestionModerationServiceTest.java
+++ b/sluv-api/src/test/java/com/sluv/api/domain/moderation/service/QuestionModerationServiceTest.java
@@ -1,0 +1,79 @@
+package com.sluv.api.domain.moderation.service;
+
+import com.sluv.api.moderation.service.QuestionModerationService;
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import com.sluv.domain.featureflag.service.FeatureFlagDomainService;
+import com.sluv.domain.moderation.service.ModerationJobDomainService;
+import com.sluv.domain.question.entity.QuestionHowabout;
+import com.sluv.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class QuestionModerationServiceTest {
+
+    @InjectMocks
+    private QuestionModerationService questionModerationService;
+
+    @Mock
+    private FeatureFlagDomainService featureFlagDomainService;
+
+    @Mock
+    private ModerationJobDomainService moderationJobDomainService;
+
+    @Test
+    @DisplayName("MODERATION_JOB_CREATION이 true면 질문 검수 작업 생성을 요청한다.")
+    void createQuestionJobIfFeatureFlagEnabledTest() {
+        // given
+        User user = User.builder().id(10L).build();
+        QuestionHowabout question = QuestionHowabout.builder()
+                .id(1L)
+                .user(user)
+                .title("질문")
+                .build();
+
+        when(featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_JOB_CREATION))
+                .thenReturn(true);
+
+        // when
+        questionModerationService.createQuestionJobIfEnabled(question);
+
+        // then
+        verify(featureFlagDomainService).isEnabled(FeatureFlagKey.MODERATION_JOB_CREATION);
+        verify(moderationJobDomainService).createQuestionJobIfAbsent(question.getId(), user.getId());
+    }
+
+    @Test
+    @DisplayName("MODERATION_JOB_CREATION이 false면 질문 검수 작업 생성을 요청하지 않는다.")
+    void doesNotCreateQuestionJobIfFeatureFlagDisabledTest() {
+        // given
+        User user = User.builder().id(10L).build();
+        QuestionHowabout question = QuestionHowabout.builder()
+                .id(1L)
+                .user(user)
+                .title("질문")
+                .build();
+
+        when(featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_JOB_CREATION))
+                .thenReturn(false);
+
+        // when
+        questionModerationService.createQuestionJobIfEnabled(question);
+
+        // then
+        verify(featureFlagDomainService).isEnabled(FeatureFlagKey.MODERATION_JOB_CREATION);
+        verify(moderationJobDomainService, never()).createQuestionJobIfAbsent(
+                anyLong(),
+                anyLong()
+        );
+    }
+}

--- a/sluv-api/src/test/java/com/sluv/api/domain/moderation/service/QuestionModerationStatusServiceTest.java
+++ b/sluv-api/src/test/java/com/sluv/api/domain/moderation/service/QuestionModerationStatusServiceTest.java
@@ -1,0 +1,81 @@
+package com.sluv.api.domain.moderation.service;
+
+import com.sluv.api.moderation.service.QuestionModerationStatusService;
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import com.sluv.domain.featureflag.service.FeatureFlagDomainService;
+import com.sluv.domain.question.enums.QuestionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class QuestionModerationStatusServiceTest {
+
+    @InjectMocks
+    private QuestionModerationStatusService questionModerationStatusService;
+
+    @Mock
+    private FeatureFlagDomainService featureFlagDomainService;
+
+    @Test
+    @DisplayName("질문 생성 PENDING 플래그가 true면 생성 상태는 PENDING이다.")
+    void getInitialQuestionStatusWithPendingFlagEnabledTest() {
+        // given
+        when(featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_QUESTION_CREATE_PENDING))
+                .thenReturn(true);
+
+        // when
+        QuestionStatus status = questionModerationStatusService.getInitialQuestionStatus();
+
+        // then
+        assertThat(status).isEqualTo(QuestionStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("질문 생성 PENDING 플래그가 false면 생성 상태는 ACTIVE다.")
+    void getInitialQuestionStatusWithPendingFlagDisabledTest() {
+        // given
+        when(featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_QUESTION_CREATE_PENDING))
+                .thenReturn(false);
+
+        // when
+        QuestionStatus status = questionModerationStatusService.getInitialQuestionStatus();
+
+        // then
+        assertThat(status).isEqualTo(QuestionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("질문 수정 PENDING 플래그가 true면 수정 상태는 PENDING이다.")
+    void getUpdateQuestionStatusWithPendingFlagEnabledTest() {
+        // given
+        when(featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_QUESTION_UPDATE_PENDING))
+                .thenReturn(true);
+
+        // when
+        QuestionStatus status = questionModerationStatusService.getUpdateQuestionStatus();
+
+        // then
+        assertThat(status).isEqualTo(QuestionStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("질문 수정 PENDING 플래그가 false면 수정 상태는 ACTIVE다.")
+    void getUpdateQuestionStatusWithPendingFlagDisabledTest() {
+        // given
+        when(featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_QUESTION_UPDATE_PENDING))
+                .thenReturn(false);
+
+        // when
+        QuestionStatus status = questionModerationStatusService.getUpdateQuestionStatus();
+
+        // then
+        assertThat(status).isEqualTo(QuestionStatus.ACTIVE);
+    }
+}

--- a/sluv-api/src/test/java/com/sluv/api/domain/question/service/QuestionServiceTest.java
+++ b/sluv-api/src/test/java/com/sluv/api/domain/question/service/QuestionServiceTest.java
@@ -1,6 +1,7 @@
 package com.sluv.api.domain.question.service;
 
 import com.sluv.api.moderation.service.QuestionModerationService;
+import com.sluv.api.moderation.service.QuestionModerationStatusService;
 import com.sluv.api.question.dto.QuestionBuyPostReqDto;
 import com.sluv.api.question.dto.QuestionFindPostReqDto;
 import com.sluv.api.question.dto.QuestionHowaboutPostReqDto;
@@ -18,6 +19,7 @@ import com.sluv.domain.question.entity.QuestionBuy;
 import com.sluv.domain.question.entity.QuestionFind;
 import com.sluv.domain.question.entity.QuestionHowabout;
 import com.sluv.domain.question.entity.QuestionRecommend;
+import com.sluv.domain.question.enums.QuestionStatus;
 import com.sluv.domain.question.service.QuestionDomainService;
 import com.sluv.domain.question.service.QuestionLikeDomainService;
 import com.sluv.domain.question.service.QuestionRecommendCategoryDomainService;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -87,6 +90,9 @@ public class QuestionServiceTest {
     @Mock
     private QuestionModerationService questionModerationService;
 
+    @Mock
+    private QuestionModerationStatusService questionModerationStatusService;
+
     @Test
     @DisplayName("찾아주세요 질문 신규 등록 후 검수 작업 생성을 요청한다.")
     void postQuestionFindCreatesModerationJobTest() {
@@ -107,6 +113,7 @@ public class QuestionServiceTest {
                 .build();
 
         when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionModerationStatusService.getInitialQuestionStatus()).thenReturn(QuestionStatus.ACTIVE);
         when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionFind.class)))
                 .thenReturn(savedQuestion);
 
@@ -139,6 +146,7 @@ public class QuestionServiceTest {
                 .build();
 
         when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionModerationStatusService.getUpdateQuestionStatus()).thenReturn(QuestionStatus.ACTIVE);
         when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionFind.class)))
                 .thenReturn(savedQuestion);
 
@@ -170,6 +178,7 @@ public class QuestionServiceTest {
                 .build();
 
         when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionModerationStatusService.getInitialQuestionStatus()).thenReturn(QuestionStatus.ACTIVE);
         when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionBuy.class)))
                 .thenReturn(savedQuestion);
 
@@ -201,6 +210,7 @@ public class QuestionServiceTest {
                 .build();
 
         when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionModerationStatusService.getInitialQuestionStatus()).thenReturn(QuestionStatus.ACTIVE);
         when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionHowabout.class)))
                 .thenReturn(savedQuestion);
 
@@ -233,6 +243,7 @@ public class QuestionServiceTest {
                 .build();
 
         when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionModerationStatusService.getInitialQuestionStatus()).thenReturn(QuestionStatus.ACTIVE);
         when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionRecommend.class)))
                 .thenReturn(savedQuestion);
 
@@ -242,6 +253,75 @@ public class QuestionServiceTest {
         // then
         assertThat(response.getId()).isEqualTo(savedQuestion.getId());
         verify(questionModerationService).createQuestionJobIfEnabled(savedQuestion);
+    }
+
+    @Test
+    @DisplayName("찾아주세요 질문 신규 등록 시 생성 PENDING 플래그가 반영된 상태로 저장한다.")
+    void postQuestionFindAppliesInitialModerationStatusTest() {
+        // given
+        Long userId = 10L;
+        User user = createUser(userId);
+        QuestionFindPostReqDto request = QuestionFindPostReqDto.builder()
+                .title("찾아주세요")
+                .content("질문 내용")
+                .imgList(List.of())
+                .itemList(List.of())
+                .build();
+        QuestionFind savedQuestion = QuestionFind.builder()
+                .id(1L)
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .questionStatus(QuestionStatus.PENDING)
+                .build();
+
+        when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionModerationStatusService.getInitialQuestionStatus()).thenReturn(QuestionStatus.PENDING);
+        when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionFind.class)))
+                .thenReturn(savedQuestion);
+
+        // when
+        questionService.postQuestionFind(userId, request);
+
+        // then
+        ArgumentCaptor<QuestionFind> captor = ArgumentCaptor.forClass(QuestionFind.class);
+        verify(questionDomainService).saveQuestion(captor.capture());
+        assertThat(captor.getValue().getQuestionStatus()).isEqualTo(QuestionStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("찾아주세요 질문 수정 시 수정 PENDING 플래그가 반영된 상태로 저장한다.")
+    void updateQuestionFindAppliesUpdateModerationStatusTest() {
+        // given
+        Long userId = 10L;
+        User user = createUser(userId);
+        QuestionFindPostReqDto request = QuestionFindPostReqDto.builder()
+                .id(1L)
+                .title("수정된 찾아주세요")
+                .content("수정된 질문 내용")
+                .imgList(List.of())
+                .itemList(List.of())
+                .build();
+        QuestionFind savedQuestion = QuestionFind.builder()
+                .id(request.getId())
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .questionStatus(QuestionStatus.PENDING)
+                .build();
+
+        when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionModerationStatusService.getUpdateQuestionStatus()).thenReturn(QuestionStatus.PENDING);
+        when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionFind.class)))
+                .thenReturn(savedQuestion);
+
+        // when
+        questionService.postQuestionFind(userId, request);
+
+        // then
+        ArgumentCaptor<QuestionFind> captor = ArgumentCaptor.forClass(QuestionFind.class);
+        verify(questionDomainService).saveQuestion(captor.capture());
+        assertThat(captor.getValue().getQuestionStatus()).isEqualTo(QuestionStatus.PENDING);
     }
 
     private User createUser(Long id) {

--- a/sluv-api/src/test/java/com/sluv/api/domain/question/service/QuestionServiceTest.java
+++ b/sluv-api/src/test/java/com/sluv/api/domain/question/service/QuestionServiceTest.java
@@ -1,0 +1,253 @@
+package com.sluv.api.domain.question.service;
+
+import com.sluv.api.moderation.service.QuestionModerationService;
+import com.sluv.api.question.dto.QuestionBuyPostReqDto;
+import com.sluv.api.question.dto.QuestionFindPostReqDto;
+import com.sluv.api.question.dto.QuestionHowaboutPostReqDto;
+import com.sluv.api.question.dto.QuestionPostResDto;
+import com.sluv.api.question.dto.QuestionRecommendPostReqDto;
+import com.sluv.api.question.helper.QuestionImageManager;
+import com.sluv.api.question.helper.QuestionItemManager;
+import com.sluv.api.question.service.QuestionService;
+import com.sluv.api.question.service.QuestionVoteService;
+import com.sluv.domain.celeb.service.CelebDomainService;
+import com.sluv.domain.celeb.service.NewCelebDomainService;
+import com.sluv.domain.closet.service.ClosetDomainService;
+import com.sluv.domain.comment.service.CommentDomainService;
+import com.sluv.domain.question.entity.QuestionBuy;
+import com.sluv.domain.question.entity.QuestionFind;
+import com.sluv.domain.question.entity.QuestionHowabout;
+import com.sluv.domain.question.entity.QuestionRecommend;
+import com.sluv.domain.question.service.QuestionDomainService;
+import com.sluv.domain.question.service.QuestionLikeDomainService;
+import com.sluv.domain.question.service.QuestionRecommendCategoryDomainService;
+import com.sluv.domain.question.service.QuestionVoteDomainService;
+import com.sluv.domain.question.service.RecentQuestionDomainService;
+import com.sluv.domain.user.entity.User;
+import com.sluv.domain.user.service.UserDomainService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class QuestionServiceTest {
+
+    @InjectMocks
+    private QuestionService questionService;
+
+    @Mock
+    private QuestionDomainService questionDomainService;
+
+    @Mock
+    private QuestionRecommendCategoryDomainService questionRecommendCategoryDomainService;
+
+    @Mock
+    private QuestionLikeDomainService questionLikeDomainService;
+
+    @Mock
+    private CommentDomainService commentDomainService;
+
+    @Mock
+    private CelebDomainService celebDomainService;
+
+    @Mock
+    private NewCelebDomainService newCelebDomainService;
+
+    @Mock
+    private RecentQuestionDomainService recentQuestionDomainService;
+
+    @Mock
+    private ClosetDomainService closetDomainService;
+
+    @Mock
+    private QuestionVoteDomainService questionVoteDomainService;
+
+    @Mock
+    private UserDomainService userDomainService;
+
+    @Mock
+    private QuestionImageManager questionImageManager;
+
+    @Mock
+    private QuestionItemManager questionItemManager;
+
+    @Mock
+    private QuestionVoteService questionVoteService;
+
+    @Mock
+    private QuestionModerationService questionModerationService;
+
+    @Test
+    @DisplayName("찾아주세요 질문 신규 등록 후 검수 작업 생성을 요청한다.")
+    void postQuestionFindCreatesModerationJobTest() {
+        // given
+        Long userId = 10L;
+        User user = createUser(userId);
+        QuestionFindPostReqDto request = QuestionFindPostReqDto.builder()
+                .title("찾아주세요")
+                .content("질문 내용")
+                .imgList(List.of())
+                .itemList(List.of())
+                .build();
+        QuestionFind savedQuestion = QuestionFind.builder()
+                .id(1L)
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionFind.class)))
+                .thenReturn(savedQuestion);
+
+        // when
+        QuestionPostResDto response = questionService.postQuestionFind(userId, request);
+
+        // then
+        assertThat(response.getId()).isEqualTo(savedQuestion.getId());
+        verify(questionModerationService).createQuestionJobIfEnabled(savedQuestion);
+    }
+
+    @Test
+    @DisplayName("찾아주세요 질문 수정 후 검수 작업 생성을 요청한다.")
+    void updateQuestionFindCreatesModerationJobTest() {
+        // given
+        Long userId = 10L;
+        User user = createUser(userId);
+        QuestionFindPostReqDto request = QuestionFindPostReqDto.builder()
+                .id(1L)
+                .title("수정된 찾아주세요")
+                .content("수정된 질문 내용")
+                .imgList(List.of())
+                .itemList(List.of())
+                .build();
+        QuestionFind savedQuestion = QuestionFind.builder()
+                .id(request.getId())
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionFind.class)))
+                .thenReturn(savedQuestion);
+
+        // when
+        QuestionPostResDto response = questionService.postQuestionFind(userId, request);
+
+        // then
+        assertThat(response.getId()).isEqualTo(savedQuestion.getId());
+        verify(questionModerationService).createQuestionJobIfEnabled(savedQuestion);
+    }
+
+    @Test
+    @DisplayName("이 중에 뭐 살까 질문 신규 등록 후 검수 작업 생성을 요청한다.")
+    void postQuestionBuyCreatesModerationJobTest() {
+        // given
+        Long userId = 10L;
+        User user = createUser(userId);
+        QuestionBuyPostReqDto request = QuestionBuyPostReqDto.builder()
+                .title("뭐 살까")
+                .voteEndTime(LocalDateTime.now().plusDays(1))
+                .imgList(List.of())
+                .itemList(List.of())
+                .build();
+        QuestionBuy savedQuestion = QuestionBuy.builder()
+                .id(2L)
+                .user(user)
+                .title(request.getTitle())
+                .voteEndTime(request.getVoteEndTime())
+                .build();
+
+        when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionBuy.class)))
+                .thenReturn(savedQuestion);
+
+        // when
+        QuestionPostResDto response = questionService.postQuestionBuy(userId, request);
+
+        // then
+        assertThat(response.getId()).isEqualTo(savedQuestion.getId());
+        verify(questionModerationService).createQuestionJobIfEnabled(savedQuestion);
+    }
+
+    @Test
+    @DisplayName("이거 어때 질문 신규 등록 후 검수 작업 생성을 요청한다.")
+    void postQuestionHowaboutCreatesModerationJobTest() {
+        // given
+        Long userId = 10L;
+        User user = createUser(userId);
+        QuestionHowaboutPostReqDto request = QuestionHowaboutPostReqDto.builder()
+                .title("이거 어때")
+                .content("질문 내용")
+                .imgList(List.of())
+                .itemList(List.of())
+                .build();
+        QuestionHowabout savedQuestion = QuestionHowabout.builder()
+                .id(3L)
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionHowabout.class)))
+                .thenReturn(savedQuestion);
+
+        // when
+        QuestionPostResDto response = questionService.postQuestionHowabout(userId, request);
+
+        // then
+        assertThat(response.getId()).isEqualTo(savedQuestion.getId());
+        verify(questionModerationService).createQuestionJobIfEnabled(savedQuestion);
+    }
+
+    @Test
+    @DisplayName("추천해줘 질문 신규 등록 후 검수 작업 생성을 요청한다.")
+    void postQuestionRecommendCreatesModerationJobTest() {
+        // given
+        Long userId = 10L;
+        User user = createUser(userId);
+        QuestionRecommendPostReqDto request = QuestionRecommendPostReqDto.builder()
+                .title("추천해줘")
+                .content("질문 내용")
+                .categoryNameList(List.of("상의"))
+                .imgList(List.of())
+                .itemList(List.of())
+                .build();
+        QuestionRecommend savedQuestion = QuestionRecommend.builder()
+                .id(4L)
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        when(userDomainService.findById(userId)).thenReturn(user);
+        when(questionDomainService.saveQuestion(org.mockito.ArgumentMatchers.any(QuestionRecommend.class)))
+                .thenReturn(savedQuestion);
+
+        // when
+        QuestionPostResDto response = questionService.postQuestionRecommend(userId, request);
+
+        // then
+        assertThat(response.getId()).isEqualTo(savedQuestion.getId());
+        verify(questionModerationService).createQuestionJobIfEnabled(savedQuestion);
+    }
+
+    private User createUser(Long id) {
+        return User.builder()
+                .id(id)
+                .email("user" + id + "@example.com")
+                .build();
+    }
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/celeb/entity/InterestedCeleb.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/celeb/entity/InterestedCeleb.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 
 @Entity
 @Getter

--- a/sluv-domain/src/main/java/com/sluv/domain/featureflag/entity/FeatureFlag.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/featureflag/entity/FeatureFlag.java
@@ -1,0 +1,44 @@
+package com.sluv.domain.featureflag.entity;
+
+import com.sluv.domain.common.entity.BaseEntity;
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "feature_flag")
+public class FeatureFlag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "feature_flag_id")
+    private Long id;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(length = 100, nullable = false, unique = true)
+    private FeatureFlagKey flagKey;
+
+    @NotNull
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @Size(max = 255)
+    private String description;
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/featureflag/enums/FeatureFlagKey.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/featureflag/enums/FeatureFlagKey.java
@@ -3,5 +3,6 @@ package com.sluv.domain.featureflag.enums;
 public enum FeatureFlagKey {
     MODERATION_JOB_CREATION,
     MODERATION_QUESTION_CREATE_PENDING,
+    MODERATION_QUESTION_UPDATE_PENDING,
     MODERATION_AUTO_APPLY_RESULT
 }

--- a/sluv-domain/src/main/java/com/sluv/domain/featureflag/enums/FeatureFlagKey.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/featureflag/enums/FeatureFlagKey.java
@@ -1,0 +1,7 @@
+package com.sluv.domain.featureflag.enums;
+
+public enum FeatureFlagKey {
+    MODERATION_JOB_CREATION,
+    MODERATION_QUESTION_CREATE_PENDING,
+    MODERATION_AUTO_APPLY_RESULT
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/featureflag/repository/FeatureFlagRepository.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/featureflag/repository/FeatureFlagRepository.java
@@ -1,0 +1,11 @@
+package com.sluv.domain.featureflag.repository;
+
+import com.sluv.domain.featureflag.entity.FeatureFlag;
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FeatureFlagRepository extends JpaRepository<FeatureFlag, Long> {
+    Optional<FeatureFlag> findByFlagKey(FeatureFlagKey flagKey);
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/featureflag/service/FeatureFlagDomainService.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/featureflag/service/FeatureFlagDomainService.java
@@ -21,7 +21,9 @@ public class FeatureFlagDomainService {
     private boolean getDefaultValue(FeatureFlagKey flagKey) {
         return switch (flagKey) {
             case MODERATION_JOB_CREATION -> true;
-            case MODERATION_QUESTION_CREATE_PENDING, MODERATION_AUTO_APPLY_RESULT -> false;
+            case MODERATION_QUESTION_CREATE_PENDING,
+                 MODERATION_QUESTION_UPDATE_PENDING,
+                 MODERATION_AUTO_APPLY_RESULT -> false;
         };
     }
 }

--- a/sluv-domain/src/main/java/com/sluv/domain/featureflag/service/FeatureFlagDomainService.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/featureflag/service/FeatureFlagDomainService.java
@@ -1,0 +1,27 @@
+package com.sluv.domain.featureflag.service;
+
+import com.sluv.domain.featureflag.entity.FeatureFlag;
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import com.sluv.domain.featureflag.repository.FeatureFlagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeatureFlagDomainService {
+
+    private final FeatureFlagRepository featureFlagRepository;
+
+    public boolean isEnabled(FeatureFlagKey flagKey) {
+        return featureFlagRepository.findByFlagKey(flagKey)
+                .map(FeatureFlag::isEnabled)
+                .orElseGet(() -> getDefaultValue(flagKey));
+    }
+
+    private boolean getDefaultValue(FeatureFlagKey flagKey) {
+        return switch (flagKey) {
+            case MODERATION_JOB_CREATION -> true;
+            case MODERATION_QUESTION_CREATE_PENDING, MODERATION_AUTO_APPLY_RESULT -> false;
+        };
+    }
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/moderation/entity/ModerationJob.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/moderation/entity/ModerationJob.java
@@ -1,0 +1,66 @@
+package com.sluv.domain.moderation.entity;
+
+import com.sluv.domain.common.entity.BaseEntity;
+import com.sluv.domain.moderation.enums.ModerationJobStatus;
+import com.sluv.domain.moderation.enums.ModerationTargetType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "moderation_job")
+public class ModerationJob extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "moderation_job_id")
+    private Long id;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(length = 45, nullable = false)
+    private ModerationTargetType targetType;
+
+    @NotNull
+    @Column(nullable = false)
+    private Long targetId;
+
+    @NotNull
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(length = 45, nullable = false, columnDefinition = "varchar(45) default 'REQUESTED'")
+    private ModerationJobStatus status = ModerationJobStatus.REQUESTED;
+
+    private Long requestedBy;
+
+    private Double score;
+
+    @Size(max = 255)
+    private String reason;
+
+    @Column(columnDefinition = "TEXT")
+    private String resultPayload;
+
+    private Long reviewedBy;
+
+    private LocalDateTime reviewedAt;
+
+    private LocalDateTime processedAt;
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/moderation/entity/ModerationJob.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/moderation/entity/ModerationJob.java
@@ -63,4 +63,13 @@ public class ModerationJob extends BaseEntity {
     private LocalDateTime reviewedAt;
 
     private LocalDateTime processedAt;
+
+    public static ModerationJob createQuestionJob(Long questionId, Long requestedBy) {
+        return ModerationJob.builder()
+                .targetType(ModerationTargetType.QUESTION)
+                .targetId(questionId)
+                .requestedBy(requestedBy)
+                .status(ModerationJobStatus.REQUESTED)
+                .build();
+    }
 }

--- a/sluv-domain/src/main/java/com/sluv/domain/moderation/enums/ModerationJobStatus.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/moderation/enums/ModerationJobStatus.java
@@ -1,0 +1,11 @@
+package com.sluv.domain.moderation.enums;
+
+public enum ModerationJobStatus {
+    REQUESTED,
+    PROCESSING,
+    NEEDS_REVIEW,
+    APPROVED,
+    REJECTED,
+    FAILED,
+    CANCELED
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/moderation/enums/ModerationTargetType.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/moderation/enums/ModerationTargetType.java
@@ -1,0 +1,5 @@
+package com.sluv.domain.moderation.enums;
+
+public enum ModerationTargetType {
+    QUESTION
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/moderation/repository/ModerationJobRepository.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/moderation/repository/ModerationJobRepository.java
@@ -1,0 +1,8 @@
+package com.sluv.domain.moderation.repository;
+
+import com.sluv.domain.moderation.entity.ModerationJob;
+import com.sluv.domain.moderation.repository.impl.ModerationJobRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ModerationJobRepository extends JpaRepository<ModerationJob, Long>, ModerationJobRepositoryCustom {
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/moderation/repository/impl/ModerationJobRepositoryCustom.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/moderation/repository/impl/ModerationJobRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.sluv.domain.moderation.repository.impl;
+
+import com.sluv.domain.moderation.enums.ModerationTargetType;
+
+public interface ModerationJobRepositoryCustom {
+    boolean existsOpenJob(ModerationTargetType targetType, Long targetId);
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/moderation/repository/impl/ModerationJobRepositoryImpl.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/moderation/repository/impl/ModerationJobRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.sluv.domain.moderation.repository.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sluv.domain.moderation.enums.ModerationJobStatus;
+import com.sluv.domain.moderation.enums.ModerationTargetType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+import static com.sluv.domain.moderation.entity.QModerationJob.moderationJob;
+
+@RequiredArgsConstructor
+public class ModerationJobRepositoryImpl implements ModerationJobRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public boolean existsOpenJob(ModerationTargetType targetType, Long targetId) {
+        Integer result = jpaQueryFactory.selectOne()
+                .from(moderationJob)
+                .where(moderationJob.targetType.eq(targetType)
+                        .and(moderationJob.targetId.eq(targetId))
+                        .and(moderationJob.status.in(getOpenStatuses()))
+                )
+                .fetchFirst();
+
+        return result != null;
+    }
+
+    private List<ModerationJobStatus> getOpenStatuses() {
+        return List.of(
+                ModerationJobStatus.REQUESTED,
+                ModerationJobStatus.PROCESSING,
+                ModerationJobStatus.NEEDS_REVIEW
+        );
+    }
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/moderation/service/ModerationJobDomainService.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/moderation/service/ModerationJobDomainService.java
@@ -1,0 +1,22 @@
+package com.sluv.domain.moderation.service;
+
+import com.sluv.domain.moderation.entity.ModerationJob;
+import com.sluv.domain.moderation.enums.ModerationTargetType;
+import com.sluv.domain.moderation.repository.ModerationJobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ModerationJobDomainService {
+
+    private final ModerationJobRepository moderationJobRepository;
+
+    public void createQuestionJobIfAbsent(Long questionId, Long requestedBy) {
+        if (moderationJobRepository.existsOpenJob(ModerationTargetType.QUESTION, questionId)) {
+            return;
+        }
+
+        moderationJobRepository.save(ModerationJob.createQuestionJob(questionId, requestedBy));
+    }
+}

--- a/sluv-domain/src/main/java/com/sluv/domain/question/entity/QuestionBuy.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/question/entity/QuestionBuy.java
@@ -27,6 +27,11 @@ public class QuestionBuy extends Question {
     }
 
     public static QuestionBuy toEntity(User user, Long questionId, String title, LocalDateTime voteEndTime) {
+        return toEntity(user, questionId, title, voteEndTime, QuestionStatus.ACTIVE);
+    }
+
+    public static QuestionBuy toEntity(User user, Long questionId, String title, LocalDateTime voteEndTime,
+                                       QuestionStatus questionStatus) {
         QuestionBuyBuilder builder = QuestionBuy.builder();
 
         if (questionId != null) {
@@ -37,7 +42,7 @@ public class QuestionBuy extends Question {
                 .user(user)
                 .title(title)
                 .voteEndTime(voteEndTime)
-                .questionStatus(QuestionStatus.ACTIVE)
+                .questionStatus(questionStatus)
                 .build();
     }
 }

--- a/sluv-domain/src/main/java/com/sluv/domain/question/entity/QuestionFind.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/question/entity/QuestionFind.java
@@ -38,6 +38,11 @@ public class QuestionFind extends Question {
 
     public static QuestionFind toEntity(User user, Long questionId, String title, String content, Celeb celeb,
                                         NewCeleb newCeleb) {
+        return toEntity(user, questionId, title, content, celeb, newCeleb, QuestionStatus.ACTIVE);
+    }
+
+    public static QuestionFind toEntity(User user, Long questionId, String title, String content, Celeb celeb,
+                                        NewCeleb newCeleb, QuestionStatus questionStatus) {
         QuestionFindBuilder builder = QuestionFind.builder();
 
         if (questionId != null) {
@@ -51,7 +56,7 @@ public class QuestionFind extends Question {
                 .content(content)
                 .celeb(celeb)
                 .newCeleb(newCeleb)
-                .questionStatus(QuestionStatus.ACTIVE)
+                .questionStatus(questionStatus)
                 .build();
     }
 }

--- a/sluv-domain/src/main/java/com/sluv/domain/question/entity/QuestionHowabout.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/question/entity/QuestionHowabout.java
@@ -20,6 +20,11 @@ public class QuestionHowabout extends Question {
     }
 
     public static QuestionHowabout toEntity(User user, Long questionId, String title, String content) {
+        return toEntity(user, questionId, title, content, QuestionStatus.ACTIVE);
+    }
+
+    public static QuestionHowabout toEntity(User user, Long questionId, String title, String content,
+                                            QuestionStatus questionStatus) {
         QuestionHowaboutBuilder builder = QuestionHowabout.builder();
 
         if (questionId != null) {
@@ -30,7 +35,7 @@ public class QuestionHowabout extends Question {
                 .user(user)
                 .title(title)
                 .content(content)
-                .questionStatus(QuestionStatus.ACTIVE)
+                .questionStatus(questionStatus)
                 .build();
     }
 }

--- a/sluv-domain/src/main/java/com/sluv/domain/question/entity/QuestionRecommend.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/question/entity/QuestionRecommend.java
@@ -20,6 +20,11 @@ public class QuestionRecommend extends Question {
     }
 
     public static QuestionRecommend toEntity(User user, Long questionId, String title, String content) {
+        return toEntity(user, questionId, title, content, QuestionStatus.ACTIVE);
+    }
+
+    public static QuestionRecommend toEntity(User user, Long questionId, String title, String content,
+                                             QuestionStatus questionStatus) {
         QuestionRecommendBuilder builder = QuestionRecommend.builder();
 
         if (questionId != null) {
@@ -31,7 +36,7 @@ public class QuestionRecommend extends Question {
                 .user(user)
                 .title(title)
                 .content(content)
-                .questionStatus(QuestionStatus.ACTIVE)
+                .questionStatus(questionStatus)
                 .build();
     }
 }

--- a/sluv-domain/src/main/java/com/sluv/domain/question/enums/QuestionStatus.java
+++ b/sluv-domain/src/main/java/com/sluv/domain/question/enums/QuestionStatus.java
@@ -2,6 +2,7 @@ package com.sluv.domain.question.enums;
 
 public enum QuestionStatus {
     ACTIVE,
+    PENDING,
     BLOCKED,
     DELETED
 }

--- a/sluv-domain/src/test/java/com/sluv/domain/featureflag/repository/FeatureFlagRepositoryTest.java
+++ b/sluv-domain/src/test/java/com/sluv/domain/featureflag/repository/FeatureFlagRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.sluv.domain.featureflag.repository;
+
+import com.sluv.domain.config.TestConfig;
+import com.sluv.domain.featureflag.entity.FeatureFlag;
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = TestConfig.class)
+@ActiveProfiles("test")
+public class FeatureFlagRepositoryTest {
+
+    @Autowired
+    private FeatureFlagRepository featureFlagRepository;
+
+    @AfterEach
+    void clean() {
+        featureFlagRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("flagKey로 Feature Flag를 조회한다.")
+    void findByFlagKeyTest() {
+        // given
+        FeatureFlag featureFlag = FeatureFlag.builder()
+                .flagKey(FeatureFlagKey.MODERATION_JOB_CREATION)
+                .enabled(true)
+                .description("게시글 업로드 시 검수 작업 생성 여부")
+                .build();
+        featureFlagRepository.save(featureFlag);
+
+        // when
+        Optional<FeatureFlag> result = featureFlagRepository.findByFlagKey(
+                FeatureFlagKey.MODERATION_JOB_CREATION
+        );
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getFlagKey()).isEqualTo(FeatureFlagKey.MODERATION_JOB_CREATION);
+        assertThat(result.get().isEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("비활성화된 Feature Flag를 저장하고 조회한다.")
+    void findDisabledFeatureFlagTest() {
+        // given
+        FeatureFlag featureFlag = FeatureFlag.builder()
+                .flagKey(FeatureFlagKey.MODERATION_AUTO_APPLY_RESULT)
+                .enabled(false)
+                .description("검수 결과 자동 반영 여부")
+                .build();
+        featureFlagRepository.save(featureFlag);
+
+        // when
+        Optional<FeatureFlag> result = featureFlagRepository.findByFlagKey(
+                FeatureFlagKey.MODERATION_AUTO_APPLY_RESULT
+        );
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getFlagKey()).isEqualTo(FeatureFlagKey.MODERATION_AUTO_APPLY_RESULT);
+        assertThat(result.get().isEnabled()).isFalse();
+    }
+}

--- a/sluv-domain/src/test/java/com/sluv/domain/featureflag/service/FeatureFlagDomainServiceTest.java
+++ b/sluv-domain/src/test/java/com/sluv/domain/featureflag/service/FeatureFlagDomainServiceTest.java
@@ -1,0 +1,88 @@
+package com.sluv.domain.featureflag.service;
+
+import com.sluv.domain.featureflag.entity.FeatureFlag;
+import com.sluv.domain.featureflag.enums.FeatureFlagKey;
+import com.sluv.domain.featureflag.repository.FeatureFlagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FeatureFlagDomainServiceTest {
+
+    @InjectMocks
+    private FeatureFlagDomainService featureFlagDomainService;
+
+    @Mock
+    private FeatureFlagRepository featureFlagRepository;
+
+    @Test
+    @DisplayName("Feature Flag가 DB에 있으면 DB 값을 반환한다.")
+    void isEnabledReturnsDatabaseValueTest() {
+        // given
+        FeatureFlag featureFlag = FeatureFlag.builder()
+                .flagKey(FeatureFlagKey.MODERATION_JOB_CREATION)
+                .enabled(false)
+                .description("게시글 업로드 시 검수 작업 생성 여부")
+                .build();
+
+        when(featureFlagRepository.findByFlagKey(FeatureFlagKey.MODERATION_JOB_CREATION))
+                .thenReturn(Optional.of(featureFlag));
+
+        // when
+        boolean enabled = featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_JOB_CREATION);
+
+        // then
+        assertThat(enabled).isFalse();
+    }
+
+    @Test
+    @DisplayName("MODERATION_JOB_CREATION이 DB에 없으면 기본값 true를 반환한다.")
+    void moderationJobCreationDefaultValueTest() {
+        // given
+        when(featureFlagRepository.findByFlagKey(FeatureFlagKey.MODERATION_JOB_CREATION))
+                .thenReturn(Optional.empty());
+
+        // when
+        boolean enabled = featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_JOB_CREATION);
+
+        // then
+        assertThat(enabled).isTrue();
+    }
+
+    @Test
+    @DisplayName("MODERATION_QUESTION_CREATE_PENDING이 DB에 없으면 기본값 false를 반환한다.")
+    void moderationQuestionCreatePendingDefaultValueTest() {
+        // given
+        when(featureFlagRepository.findByFlagKey(FeatureFlagKey.MODERATION_QUESTION_CREATE_PENDING))
+                .thenReturn(Optional.empty());
+
+        // when
+        boolean enabled = featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_QUESTION_CREATE_PENDING);
+
+        // then
+        assertThat(enabled).isFalse();
+    }
+
+    @Test
+    @DisplayName("MODERATION_AUTO_APPLY_RESULT가 DB에 없으면 기본값 false를 반환한다.")
+    void moderationAutoApplyResultDefaultValueTest() {
+        // given
+        when(featureFlagRepository.findByFlagKey(FeatureFlagKey.MODERATION_AUTO_APPLY_RESULT))
+                .thenReturn(Optional.empty());
+
+        // when
+        boolean enabled = featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_AUTO_APPLY_RESULT);
+
+        // then
+        assertThat(enabled).isFalse();
+    }
+}

--- a/sluv-domain/src/test/java/com/sluv/domain/featureflag/service/FeatureFlagDomainServiceTest.java
+++ b/sluv-domain/src/test/java/com/sluv/domain/featureflag/service/FeatureFlagDomainServiceTest.java
@@ -85,4 +85,18 @@ public class FeatureFlagDomainServiceTest {
         // then
         assertThat(enabled).isFalse();
     }
+
+    @Test
+    @DisplayName("MODERATION_QUESTION_UPDATE_PENDING이 DB에 없으면 기본값 false를 반환한다.")
+    void moderationQuestionUpdatePendingDefaultValueTest() {
+        // given
+        when(featureFlagRepository.findByFlagKey(FeatureFlagKey.MODERATION_QUESTION_UPDATE_PENDING))
+                .thenReturn(Optional.empty());
+
+        // when
+        boolean enabled = featureFlagDomainService.isEnabled(FeatureFlagKey.MODERATION_QUESTION_UPDATE_PENDING);
+
+        // then
+        assertThat(enabled).isFalse();
+    }
 }

--- a/sluv-domain/src/test/java/com/sluv/domain/moderation/repository/ModerationJobRepositoryTest.java
+++ b/sluv-domain/src/test/java/com/sluv/domain/moderation/repository/ModerationJobRepositoryTest.java
@@ -1,0 +1,124 @@
+package com.sluv.domain.moderation.repository;
+
+import com.sluv.domain.config.TestConfig;
+import com.sluv.domain.moderation.entity.ModerationJob;
+import com.sluv.domain.moderation.enums.ModerationJobStatus;
+import com.sluv.domain.moderation.enums.ModerationTargetType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = TestConfig.class)
+@ActiveProfiles("test")
+public class ModerationJobRepositoryTest {
+
+    @Autowired
+    private ModerationJobRepository moderationJobRepository;
+
+    @AfterEach
+    void clean() {
+        moderationJobRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("moderation job을 저장한다.")
+    void saveModerationJobTest() {
+        // given
+        ModerationJob moderationJob = createJob(1L, ModerationJobStatus.REQUESTED);
+
+        // when
+        ModerationJob savedJob = moderationJobRepository.save(moderationJob);
+
+        // then
+        assertThat(savedJob.getId()).isNotNull();
+        assertThat(savedJob.getTargetType()).isEqualTo(ModerationTargetType.QUESTION);
+        assertThat(savedJob.getTargetId()).isEqualTo(1L);
+        assertThat(savedJob.getStatus()).isEqualTo(ModerationJobStatus.REQUESTED);
+        assertThat(savedJob.getRequestedBy()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("REQUESTED 상태의 moderation job은 open job으로 판단한다.")
+    void requestedJobIsOpenJobTest() {
+        // given
+        moderationJobRepository.save(createJob(1L, ModerationJobStatus.REQUESTED));
+
+        // when
+        boolean exists = moderationJobRepository.existsOpenJob(ModerationTargetType.QUESTION, 1L);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("PROCESSING 상태의 moderation job은 open job으로 판단한다.")
+    void processingJobIsOpenJobTest() {
+        // given
+        moderationJobRepository.save(createJob(1L, ModerationJobStatus.PROCESSING));
+
+        // when
+        boolean exists = moderationJobRepository.existsOpenJob(ModerationTargetType.QUESTION, 1L);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("NEEDS_REVIEW 상태의 moderation job은 open job으로 판단한다.")
+    void needsReviewJobIsOpenJobTest() {
+        // given
+        moderationJobRepository.save(createJob(1L, ModerationJobStatus.NEEDS_REVIEW));
+
+        // when
+        boolean exists = moderationJobRepository.existsOpenJob(ModerationTargetType.QUESTION, 1L);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("완료 상태의 moderation job은 open job으로 판단하지 않는다.")
+    void completedJobIsNotOpenJobTest() {
+        // given
+        moderationJobRepository.save(createJob(1L, ModerationJobStatus.APPROVED));
+        moderationJobRepository.save(createJob(1L, ModerationJobStatus.REJECTED));
+        moderationJobRepository.save(createJob(1L, ModerationJobStatus.FAILED));
+        moderationJobRepository.save(createJob(1L, ModerationJobStatus.CANCELED));
+
+        // when
+        boolean exists = moderationJobRepository.existsOpenJob(ModerationTargetType.QUESTION, 1L);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("다른 targetId의 moderation job은 open job으로 판단하지 않는다.")
+    void differentTargetIdIsNotOpenJobTest() {
+        // given
+        moderationJobRepository.save(createJob(1L, ModerationJobStatus.REQUESTED));
+
+        // when
+        boolean exists = moderationJobRepository.existsOpenJob(ModerationTargetType.QUESTION, 2L);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    private ModerationJob createJob(Long targetId, ModerationJobStatus status) {
+        return ModerationJob.builder()
+                .targetType(ModerationTargetType.QUESTION)
+                .targetId(targetId)
+                .status(status)
+                .requestedBy(10L)
+                .reason("테스트")
+                .build();
+    }
+}

--- a/sluv-domain/src/test/java/com/sluv/domain/moderation/service/ModerationJobDomainServiceTest.java
+++ b/sluv-domain/src/test/java/com/sluv/domain/moderation/service/ModerationJobDomainServiceTest.java
@@ -1,0 +1,72 @@
+package com.sluv.domain.moderation.service;
+
+import com.sluv.domain.moderation.entity.ModerationJob;
+import com.sluv.domain.moderation.enums.ModerationJobStatus;
+import com.sluv.domain.moderation.enums.ModerationTargetType;
+import com.sluv.domain.moderation.repository.ModerationJobRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ModerationJobDomainServiceTest {
+
+    @InjectMocks
+    private ModerationJobDomainService moderationJobDomainService;
+
+    @Mock
+    private ModerationJobRepository moderationJobRepository;
+
+    @Test
+    @DisplayName("open job이 없으면 REQUESTED 상태의 질문 검수 작업을 생성한다.")
+    void createQuestionJobIfOpenJobDoesNotExistTest() {
+        // given
+        Long questionId = 1L;
+        Long requestedBy = 10L;
+
+        when(moderationJobRepository.existsOpenJob(ModerationTargetType.QUESTION, questionId))
+                .thenReturn(false);
+
+        // when
+        moderationJobDomainService.createQuestionJobIfAbsent(questionId, requestedBy);
+
+        // then
+        verify(moderationJobRepository).existsOpenJob(ModerationTargetType.QUESTION, questionId);
+
+        ArgumentCaptor<ModerationJob> captor = ArgumentCaptor.forClass(ModerationJob.class);
+        verify(moderationJobRepository).save(captor.capture());
+
+        ModerationJob savedJob = captor.getValue();
+        assertThat(savedJob.getTargetType()).isEqualTo(ModerationTargetType.QUESTION);
+        assertThat(savedJob.getTargetId()).isEqualTo(questionId);
+        assertThat(savedJob.getRequestedBy()).isEqualTo(requestedBy);
+        assertThat(savedJob.getStatus()).isEqualTo(ModerationJobStatus.REQUESTED);
+    }
+
+    @Test
+    @DisplayName("open job이 있으면 질문 검수 작업을 중복 생성하지 않는다.")
+    void doesNotCreateQuestionJobIfOpenJobExistsTest() {
+        // given
+        Long questionId = 1L;
+        Long requestedBy = 10L;
+
+        when(moderationJobRepository.existsOpenJob(ModerationTargetType.QUESTION, questionId))
+                .thenReturn(true);
+
+        // when
+        moderationJobDomainService.createQuestionJobIfAbsent(questionId, requestedBy);
+
+        // then
+        verify(moderationJobRepository).existsOpenJob(ModerationTargetType.QUESTION, questionId);
+        verify(moderationJobRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/sluv-domain/src/test/java/com/sluv/domain/question/entity/QuestionStatusTest.java
+++ b/sluv-domain/src/test/java/com/sluv/domain/question/entity/QuestionStatusTest.java
@@ -1,0 +1,82 @@
+package com.sluv.domain.question.entity;
+
+import com.sluv.domain.question.enums.QuestionStatus;
+import com.sluv.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QuestionStatusTest {
+
+    @Test
+    @DisplayName("질문 상태에 PENDING이 존재한다.")
+    void questionStatusHasPendingTest() {
+        // when
+        QuestionStatus status = QuestionStatus.valueOf("PENDING");
+
+        // then
+        assertThat(status.name()).isEqualTo("PENDING");
+    }
+
+    @Test
+    @DisplayName("찾아주세요 질문 생성 시 상태는 ACTIVE다.")
+    void questionFindDefaultStatusIsActiveTest() {
+        // given
+        User user = createUser();
+
+        // when
+        QuestionFind question = QuestionFind.toEntity(user, null, "찾아주세요", "내용", null, null);
+
+        // then
+        assertThat(question.getQuestionStatus()).isEqualTo(QuestionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("이 중에 뭐 살까 질문 생성 시 상태는 ACTIVE다.")
+    void questionBuyDefaultStatusIsActiveTest() {
+        // given
+        User user = createUser();
+
+        // when
+        QuestionBuy question = QuestionBuy.toEntity(user, null, "뭐 살까", LocalDateTime.now().plusDays(1));
+
+        // then
+        assertThat(question.getQuestionStatus()).isEqualTo(QuestionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("이거 어때 질문 생성 시 상태는 ACTIVE다.")
+    void questionHowaboutDefaultStatusIsActiveTest() {
+        // given
+        User user = createUser();
+
+        // when
+        QuestionHowabout question = QuestionHowabout.toEntity(user, null, "이거 어때", "내용");
+
+        // then
+        assertThat(question.getQuestionStatus()).isEqualTo(QuestionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("추천해줘 질문 생성 시 상태는 ACTIVE다.")
+    void questionRecommendDefaultStatusIsActiveTest() {
+        // given
+        User user = createUser();
+
+        // when
+        QuestionRecommend question = QuestionRecommend.toEntity(user, null, "추천해줘", "내용");
+
+        // then
+        assertThat(question.getQuestionStatus()).isEqualTo(QuestionStatus.ACTIVE);
+    }
+
+    private User createUser() {
+        return User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .build();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/clean-post -> develop

### 변경 사항
1차 릴리즈를 위한 게시글 검수 기반 구조를 추가했습니다.

질문 게시글 상태에 PENDING을 추가했습니다.
- moderation_job 도메인을 추가했습니다.
    - 검수 대상 식별을 위해 targetType, targetId 구조를 추가했습니다.
    - 검수 작업 상태로 REQUESTED, PROCESSING, NEEDS_REVIEW, APPROVED, REJECTED, FAILED, CANCELED를 추가했습니다.
    - REQUESTED, PROCESSING, NEEDS_REVIEW 상태의 open job이 있으면 중복 생성되지 않도록 QueryDSL 조회를 추가했습니다.
- DB 기반 기능 플래그 도메인을 추가했습니다.
    - MODERATION_JOB_CREATION
    - MODERATION_QUESTION_CREATE_PENDING
    - MODERATION_QUESTION_UPDATE_PENDING
    - MODERATION_AUTO_APPLY_RESULT
- 게시글 등록/수정 시 검수 작업 생성 흐름을 연결했습니다.
    - MODERATION_JOB_CREATION이 활성화된 경우 검수 작업을 생성합니다.
    - open job이 이미 있으면 중복 생성하지 않습니다.
- 게시글 생성/수정 시 PENDING 저장 여부를 기능 플래그로 제어할 수 있게 했습니다.
    - 신규 생성: MODERATION_QUESTION_CREATE_PENDING
    - 수정: MODERATION_QUESTION_UPDATE_PENDING
- org.springframework.lang.Nullable 사용을 jakarta.annotation.Nullable로 통일해 When.MAYBE 컴파일 warning 원인을 제거했습니다.

### 테스트 결과
<img width="780" height="293" alt="스크린샷 2026-04-21 오후 10 44 55" src="https://github.com/user-attachments/assets/0d98fcde-d954-4a2c-abbd-3cf1f1ce0329" />
